### PR TITLE
Fix compilation errors with latest libraries

### DIFF
--- a/source/fceugx.cpp
+++ b/source/fceugx.cpp
@@ -47,15 +47,16 @@
 
 #include "fceultra/types.h"
 
-void FCEUD_Update(uint8 *XBuf, int32 *Buffer, int Count);
-void FCEUD_UpdatePulfrich(uint8 *XBuf, int32 *Buffer, int Count);
-void FCEUD_UpdateLeft(uint8 *XBuf, int32 *Buffer, int Count);
-void FCEUD_UpdateRight(uint8 *XBuf, int32 *Buffer, int Count);
+void FCEUD_Update(uint8 *XBuf, int32 *Buffer, int32 Count);
+void FCEUD_UpdatePulfrich(uint8 *XBuf, int32 *Buffer, int32 Count);
+void FCEUD_UpdateLeft(uint8 *XBuf, int32 *Buffer, int32 Count);
+void FCEUD_UpdateRight(uint8 *XBuf, int32 *Buffer, int32 Count);
 
 extern "C" {
 #ifdef USE_VM
 	#include "utils/vm/vm.h"
 #endif
+extern char* strcasestr(const char *, const char *);
 extern void __exception_setreload(int t);
 }
 
@@ -292,7 +293,7 @@ bool SaneIOS(u32 ios)
 static bool gecko = false;
 static mutex_t gecko_mutex = 0;
 
-static ssize_t __out_write(struct _reent *r, int fd, const char *ptr, size_t len)
+static ssize_t __out_write(struct _reent *r, void* fd, const char *ptr, size_t len)
 {
 	if (!gecko || len == 0)
 		return len;

--- a/source/fceugx.h
+++ b/source/fceugx.h
@@ -12,6 +12,7 @@
 #ifndef _FCEUGX_H_
 #define _FCEUGX_H_
 
+#define MAXPATHLEN 1024
 #include <unistd.h>
 
 #include "fceultra/driver.h"

--- a/source/fceultra/boards/emu2413.h
+++ b/source/fceultra/boards/emu2413.h
@@ -17,14 +17,14 @@
 extern "C" {
 #endif
 
-typedef unsigned char uint8 ;
-typedef signed char int8 ;
+typedef uint8_t uint8 ;
+typedef int8_t int8 ;
 
-typedef unsigned short uint16 ;
-typedef signed short int16 ;
+typedef uint16_t uint16 ;
+typedef int16_t int16 ;
 
-typedef unsigned int uint32 ;
-typedef signed int int32 ;
+typedef uint32_t uint32 ;
+typedef int32_t int32 ;
 
 #define PI 3.14159265358979323846
 

--- a/source/fceultra/cart.cpp
+++ b/source/fceultra/cart.cpp
@@ -240,7 +240,7 @@ void setchr2r(int r, uint32 A, uint32 V) {
 		PPUCHRRAM &= ~(3 << (A >> 10));
 }
 
-void setchr4r(int r, unsigned int A, unsigned int V) {
+void setchr4r(int r, uint32 A, uint32 V) {
 	if (!CHRptr[r]) return;
 	FCEUPPU_LineUpdate();
 	V &= CHRmask4[r];

--- a/source/fceultra/cart.h
+++ b/source/fceultra/cart.h
@@ -66,21 +66,21 @@ void setprg8(uint32 A, uint32 V);
 void setprg16(uint32 A, uint32 V);
 void setprg32(uint32 A, uint32 V);
 
-void setprg2r(int r, unsigned int A, unsigned int V);
-void setprg4r(int r, unsigned int A, unsigned int V);
-void setprg8r(int r, unsigned int A, unsigned int V);
-void setprg16r(int r, unsigned int A, unsigned int V);
-void setprg32r(int r, unsigned int A, unsigned int V);
+void setprg2r(int r, uint32 A, uint32 V);
+void setprg4r(int r, uint32 A, uint32 V);
+void setprg8r(int r, uint32 A, uint32 V);
+void setprg16r(int r, uint32 A, uint32 V);
+void setprg32r(int r, uint32 A, uint32 V);
 
-void setchr1r(int r, unsigned int A, unsigned int V);
-void setchr2r(int r, unsigned int A, unsigned int V);
-void setchr4r(int r, unsigned int A, unsigned int V);
-void setchr8r(int r, unsigned int V);
+void setchr1r(int r, uint32 A, uint32 V);
+void setchr2r(int r, uint32 A, uint32 V);
+void setchr4r(int r, uint32 A, uint32 V);
+void setchr8r(int r, uint32 V);
 
-void setchr1(unsigned int A, unsigned int V);
-void setchr2(unsigned int A, unsigned int V);
-void setchr4(unsigned int A, unsigned int V);
-void setchr8(unsigned int V);
+void setchr1(uint32 A, uint32 V);
+void setchr2(uint32 A, uint32 V);
+void setchr4(uint32 A, uint32 V);
+void setchr8(uint32 V);
 
 void setmirror(int t);
 void setmirrorw(int a, int b, int c, int d);

--- a/source/filebrowser.cpp
+++ b/source/filebrowser.cpp
@@ -331,7 +331,7 @@ int FileSortCallback(const void *f1, const void *f2)
 	if(((BROWSERENTRY *)f1)->isdir && !(((BROWSERENTRY *)f2)->isdir)) return -1;
 	if(!(((BROWSERENTRY *)f1)->isdir) && ((BROWSERENTRY *)f2)->isdir) return 1;
 
-	return stricmp(((BROWSERENTRY *)f1)->filename, ((BROWSERENTRY *)f2)->filename);
+	return strcasecmp(((BROWSERENTRY *)f1)->filename, ((BROWSERENTRY *)f2)->filename);
 }
 
 /****************************************************************************
@@ -366,7 +366,7 @@ static bool IsValidROM()
 			
 			char * zippedFilename = NULL;
 
-			if(stricmp(p, ".zip") == 0 && !inSz)
+			if(strcasecmp(p, ".zip") == 0 && !inSz)
 			{
 				// we need to check the file extension of the first file in the archive
 				zippedFilename = GetFirstZipFilename ();
@@ -380,12 +380,12 @@ static bool IsValidROM()
 			if(p != NULL)
 			{
 				if (
-					stricmp(p, ".nes") == 0 ||
-					stricmp(p, ".fds") == 0 ||
-					stricmp(p, ".nsf") == 0 ||
-					stricmp(p, ".unf") == 0 ||
-					stricmp(p, ".nez") == 0 ||
-					stricmp(p, ".unif") == 0
+					strcasecmp(p, ".nes") == 0 ||
+					strcasecmp(p, ".fds") == 0 ||
+					strcasecmp(p, ".nsf") == 0 ||
+					strcasecmp(p, ".unf") == 0 ||
+					strcasecmp(p, ".nez") == 0 ||
+					strcasecmp(p, ".unif") == 0
 				)
 				{
 					if(zippedFilename) free(zippedFilename);
@@ -411,7 +411,7 @@ bool IsSz()
 		char * p = strrchr(browserList[browser.selIndex].filename, '.');
 
 		if (p != NULL)
-			if(stricmp(p, ".7z") == 0)
+			if(strcasecmp(p, ".7z") == 0)
 				return true;
 	}
 	return false;

--- a/source/fileop.cpp
+++ b/source/fileop.cpp
@@ -566,11 +566,11 @@ static bool ParseDirEntries()
 				if(ext == NULL)
 					continue;
 
-				if(	stricmp(ext, "nes") != 0 && stricmp(ext, "fds") != 0 &&
-					stricmp(ext, "nsf") != 0 && stricmp(ext, "unf") != 0 &&
-					stricmp(ext, "nez") != 0 && stricmp(ext, "unif") != 0 &&
-					stricmp(ext, "gba") != 0 &&
-					stricmp(ext, "zip") != 0 && stricmp(ext, "7z") != 0)
+				if(	strcasecmp(ext, "nes") != 0 && strcasecmp(ext, "fds") != 0 &&
+					strcasecmp(ext, "nsf") != 0 && strcasecmp(ext, "unf") != 0 &&
+					strcasecmp(ext, "nez") != 0 && strcasecmp(ext, "unif") != 0 &&
+					strcasecmp(ext, "gba") != 0 &&
+					strcasecmp(ext, "zip") != 0 && strcasecmp(ext, "7z") != 0)
 					continue;
 			}
 		}

--- a/source/gcaudio.cpp
+++ b/source/gcaudio.cpp
@@ -156,7 +156,7 @@ void ShutdownAudio()
  * Puts incoming mono samples into mixbuffer
  * Splits mono samples into two channels (stereo)
  ****************************************************************************/
-void PlaySound( int *Buffer, int count )
+void PlaySound( int32 *Buffer, int count )
 {
 	int i;
 	u16 sample;

--- a/source/gcaudio.h
+++ b/source/gcaudio.h
@@ -12,7 +12,7 @@
 
 void InitialiseAudio();
 void ResetAudio();
-void PlaySound( int *Buffer, int samples );
+void PlaySound( int32 *Buffer, int samples );
 void SwitchAudioMode(int mode);
 void ShutdownAudio();
 void UpdateSampleRate(int rate);

--- a/source/gcvideo.cpp
+++ b/source/gcvideo.cpp
@@ -34,7 +34,7 @@ int FDSSwitchRequested;
 /*** External 2D Video ***/
 /*** 2D Video Globals ***/
 GXRModeObj *vmode  = NULL; // Graphics Mode Object
-static unsigned int *xfb[2] = { NULL, NULL }; // Framebuffers
+static u32 *xfb[2] = { NULL, NULL }; // Framebuffers
 static int whichfb = 0; // Frame buffer toggle
 int screenheight = 480;
 int screenwidth = 640;

--- a/source/networkop.cpp
+++ b/source/networkop.cpp
@@ -315,7 +315,7 @@ bool InitializeNetwork(bool silent)
 				break;
 		}
 #else
-		networkInit = !(if_config(wiiIP, NULL, NULL, true) < 0);
+		networkInit = !(if_config(wiiIP, NULL, NULL, true, 10) < 0);
 #endif
 
 		CancelAction();

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -65,7 +65,7 @@ static void createXMLSetting(const char * name, const char * description, const 
 	mxmlElementSetAttr(item, "description", description);
 }
 
-static void createXMLController(unsigned int controller[], const char * name, const char * description)
+static void createXMLController(u32 controller[], const char * name, const char * description)
 {
 	item = mxmlNewElement(section, "controller");
 	mxmlElementSetAttr(item, "name", name);
@@ -154,7 +154,9 @@ preparePrefsData ()
 
 	createXMLSection("Menu", "Menu Settings");
 
+#ifdef HW_RVL
 	createXMLSetting("WiimoteOrientation", "Wiimote Orientation", toStr(GCSettings.WiimoteOrientation));
+#endif
 	createXMLSetting("ExitAction", "Exit Action", toStr(GCSettings.ExitAction));
 	createXMLSetting("MusicVolume", "Music Volume", toStr(GCSettings.MusicVolume));
 	createXMLSetting("SFXVolume", "Sound Effects Volume", toStr(GCSettings.SFXVolume));
@@ -225,7 +227,7 @@ static void loadXMLSetting(float * var, const char * name)
  * Load XML elements into variables for a controller mapping
  ***************************************************************************/
 
-static void loadXMLController(unsigned int controller[], const char * name)
+static void loadXMLController(u32 controller[], const char * name)
 {
 	item = mxmlFindElement(xml, xml, "controller", "name", name, MXML_DESCEND);
 


### PR DESCRIPTION
Part of this is ported from snes9xgx: https://github.com/dborth/snes9xgx/commit/a4177458176bfdf2881aebf3204c0a4fb5083640

I also changed some int* to int32* - I think they were 32-bit, the way they were being used.

There are a couple files with line ending changes, sorry about that. I can redo this commit to fix that if you want.