### PR TITLE
Allow loader to pass 2 arguments instead of 3 for autoload

### DIFF
--- a/source/fceugx.cpp
+++ b/source/fceugx.cpp
@@ -438,7 +438,7 @@ int main(int argc, char *argv[])
 	int currentTiming = 0;
 
 	bool autoboot = false;
-	if(argc > 3 && argv[1] != NULL && argv[2] != NULL && argv[3] != NULL)
+	if(argc > 2 && argv[1] != NULL && argv[2] != NULL)
 	{
 		autoboot = true;
 		ResetBrowser();
@@ -461,7 +461,7 @@ int main(int argc, char *argv[])
 		strncpy(arg_filename, argv[2], sizeof(arg_filename));
 		strncpy(GCSettings.LoadFolder, dir.c_str(), sizeof(GCSettings.LoadFolder));
 		OpenGameList();
-		strncpy(GCSettings.Exit_Dol_File, argv[3], sizeof(GCSettings.Exit_Dol_File));
+		strncpy(GCSettings.Exit_Dol_File, argc > 3 && argv[3] != NULL ? argv[3] : "", sizeof(GCSettings.Exit_Dol_File));
 		if(argc > 5 && argv[4] != NULL && argv[5] != NULL)
 		{
 			sscanf(argv[4], "%08x", &GCSettings.Exit_Channel[0]);


### PR DESCRIPTION
fceugx version of: https://github.com/dborth/snes9xgx/pull/728