### PR TITLE
Refactor make files and change artifact output

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -16,9 +16,26 @@ jobs:
     - name: Build
       run: |
         make -j2
+    
+    - name: Copy files
+      run: | 
+        cp -f hbc/* executables/FCEUltraGX/apps/fceugx/
+        cp -f hbc/* executables/FCEUltraGX-GameCube/
+        cp -f README.md executables/FCEUltraGX/apps/fceugx/
+        cp -f README.md executables/FCEUltraGX-GameCube/
 
-    - name: Upload a Build Artifact
+    - name: Upload Wii Build Artifacts
       uses: actions/upload-artifact@v2
       with: 
-        name: executables
-        path: executables/*
+        name: FCEUltraGX-Nightly
+        path: |
+         executables/FCEUltraGX/
+         !executables/FCEUltraGX/apps/fceugx/*.elf
+    
+    - name: Upload GameCube Build Artifacts
+      uses: actions/upload-artifact@v2
+      with: 
+        name: FCEUltraGX-Nightly-GameCube
+        path: |
+         executables/FCEUltraGX-GameCube/
+         !executables/FCEUltraGX-GameCube/*.elf

--- a/Makefile.gc
+++ b/Makefile.gc
@@ -11,12 +11,13 @@ include $(DEVKITPPC)/gamecube_rules
 
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
+# TARGETDIR is the directory where the output files will be placed
 # BUILD is the directory where object files & intermediate files will be placed
 # SOURCES is a list of directories containing source code
 # INCLUDES is a list of directories containing extra header files
 #---------------------------------------------------------------------------------
-TARGET		:=	fceugx-gc
-TARGETDIR   :=  executables
+TARGET		:=	boot
+TARGETDIR   :=  executables/FCEUltraGX-GameCube
 BUILD		:=	build_gc
 SOURCES		:=	source source/gui source/utils source/utils/unzip source/utils/sz \
 				source/fceultra source/fceultra/boards source/fceultra/input \
@@ -117,7 +118,7 @@ $(BUILD):
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
-	@rm -fr $(BUILD) $(OUTPUT).elf $(OUTPUT).dol
+	@rm -fr $(BUILD) $(TARGETDIR)
 
 #---------------------------------------------------------------------------------
 run:

--- a/Makefile.wii
+++ b/Makefile.wii
@@ -11,13 +11,18 @@ include $(DEVKITPPC)/wii_rules
 
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
+# TARGETDIR is the directory where the output files will be placed
+# SUBDIR are the directories where the cheats, roms and saves need to be placed
+# ROOTDIR is the root directory of the build
 # BUILD is the directory where object files & intermediate files will be placed
 # SOURCES is a list of directories containing source code
 # INCLUDES is a list of directories containing extra header files
 #---------------------------------------------------------------------------------
-TARGET		:=	fceugx-wii
-TARGETDIR	:=  executables
-BUILD			:=	build_wii
+TARGET		:=	boot
+TARGETDIR	:=  executables/FCEUltraGX/apps/fceugx
+ROOTDIR		:=	executables/FCEUltraGX
+SUBDIR		:=	executables/FCEUltraGX/fceugx/{cheats,roms,saves}
+BUILD		:=	build_wii
 SOURCES		:=	source source/gui source/utils source/utils/sz source/utils/unzip \
 				source/fceultra source/fceultra/boards source/fceultra/input \
 				source/fceultra/utils source/fceultra/mbshare \
@@ -112,13 +117,13 @@ export OUTPUT	:=	$(CURDIR)/$(TARGETDIR)/$(TARGET)
 #---------------------------------------------------------------------------------
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
-	@[ -d $(TARGETDIR) ] || mkdir -p $(TARGETDIR)
+	@[ -d $(TARGETDIR) ] || mkdir -p $(TARGETDIR) $(SUBDIR)
 	@make --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile.wii
 
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
-	@rm -fr $(BUILD) $(OUTPUT).elf $(OUTPUT).dol
+	@rm -fr $(BUILD) $(ROOTDIR)
 
 #---------------------------------------------------------------------------------
 run:


### PR DESCRIPTION
This changes the following:
- Uploads a separate Wii and Gamecube artifact
- Excludes uploading the elf files
- Creates the complete Wii structure under executables/FCEUltraGX
- Creates the complete GameCube structure under executables/FCEUltraGX-GameCube
- Doesn't upload empty folders like the fceugx folder with cheats, roms and saves but it is created in a local environment