### PR TITLE
Increase max number of palettes to 11

### DIFF
--- a/source/gcvideo.h
+++ b/source/gcvideo.h
@@ -13,7 +13,7 @@
 #define _GCVIDEO_H_
 
 // color palettes
-#define MAXPAL 7
+#define MAXPAL 11
 
 struct st_palettes {
     char name[32], desc[32];


### PR DESCRIPTION
Hi @dborth

I forgot to add this when i added the new color palettes to FCE Ultra GX code for a next version, in this pull request https://github.com/dborth/fceugx/pull/443

I modified in gcvideo.h the MAXPAL value for change from number 7 to 11 for be able to store the new color palettes i'm adding.

(my edit is still experimental, i want to see if these work on the final compiled version of FCEUGX Wii)

Greetings