### PR TITLE
Allow "Original" render mode in 480p configurations

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3423,10 +3423,6 @@ static int MenuSettingsVideo()
 		{
 			firstRun = false;
 
-			// don't allow original render mode if progressive video mode detected
-			if (GCSettings.render==0 && progressive)
-				GCSettings.render++;
-
 			if (GCSettings.render == 0)
 				sprintf (options.value[0], "Original");
 			else if (GCSettings.render == 1)


### PR DESCRIPTION
This commit will allow us to use "Original" render mode when our "TV Resolution" settings on "Wii Settings" are set to "EDTV or HDTV (480p)" over component cables:
This caters specifically to LCD / LED users with 240p supported displays, since the option was previously hidden. Users with CRT / PVM / BVM displays with supported 480p Progressive Scan mode will also benefit, since no Wii setting switch will be needed for the "Original" 240p mode to be used.

This was based in niuus' commit for bring 240p support to 480p setting in Snes9x RX, but checking the code in main Visual Boy Advance GX it has 240p support by removing some "unused" code in this commit, and trying also to implement to Snes9x GX, which I (saulfabreg) tested previously in a test build and it works.

Hope can also be added to FCE Ultra GX?

Thanks, @saulfabregwiivc 