### PR TITLE
Add "Enable Turbo Mode" toggle to the Video Settings menu (based on InfiniteBlueGX's code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FCE Ultra GX
+# FCE Ultra GX (Turbo Mode modified)
 https://github.com/dborth/fceugx (Under GPL License)
  
 FCE Ultra GX is a modified port of the FCE Ultra Nintendo Entertainment

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FCE Ultra GX (Turbo Mode modified)
+# FCE Ultra GX
 https://github.com/dborth/fceugx (Under GPL License)
  
 FCE Ultra GX is a modified port of the FCE Ultra Nintendo Entertainment

--- a/source/fceugx.h
+++ b/source/fceugx.h
@@ -121,6 +121,7 @@ struct SGCSettings
 	int		Rumble;
 	int 	language;
 	int		PreviewImage;
+	int		TurboModeEnabled; // 0 - disabled, 1 - enabled
 };
 
 void ExitApp();

--- a/source/lang/es.lang
+++ b/source/lang/es.lang
@@ -721,6 +721,9 @@ msgstr "Desactivado"
 msgid "distributed, or modified under the terms of the"
 msgstr "distribuido, o modificado bajo los términos de"
 
+msgid "Enable Turbo Mode"
+msgstr "Activar Modo Turbo"
+
 msgid "FDS BIOS file is invalid!"
 msgstr "¡Archivo de BIOS de FDS inválido!"
 

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3319,6 +3319,7 @@ static int MenuSettingsVideo()
 	sprintf(options.name[i++], "Zapper Crosshair");
 	sprintf(options.name[i++], "Sprite Limit");
 	sprintf(options.name[i++], "Video Mode");
+	sprintf(options.name[i++], "Enable Turbo Mode");
 	options.length = i;
 
 	for(i=0; i < options.length; i++)
@@ -3417,6 +3418,11 @@ static int MenuSettingsVideo()
 				if(GCSettings.videomode > 4)
 					GCSettings.videomode = 0;
 				break;
+			case 10:
+				GCSettings.TurboModeEnabled++;
+				if (GCSettings.TurboModeEnabled > 1)
+					GCSettings.TurboModeEnabled = 0;
+				break;
 		}
 
 		if(ret >= 0 || firstRun)
@@ -3476,6 +3482,7 @@ static int MenuSettingsVideo()
 				case 4:
 					sprintf (options.value[9], "PAL (60Hz)"); break;
 			}
+			sprintf (options.value[10], "%s", GCSettings.TurboModeEnabled == 1 ? "On" : "Off");
 			optionBrowser.TriggerUpdate();
 		}
 

--- a/source/pad.cpp
+++ b/source/pad.cpp
@@ -631,11 +631,13 @@ void GetJoy()
 
 	// Turbo mode
 	// RIGHT on c-stick and on classic ctrlr right joystick
-	if(userInput[0].pad.substickX > 70 || userInput[0].WPAD_StickX(1) > 70 || userInput[0].wiidrcdata.substickX > 45)
-		turbomode = 1;
-	else
-		turbomode = 0;
-
+	if (GCSettings.TurboModeEnabled == 1)
+	{
+		if(userInput[0].pad.substickX > 70 || userInput[0].WPAD_StickX(1) > 70 || userInput[0].wiidrcdata.substickX > 45)
+			turbomode = 1;
+		else
+			turbomode = 0;
+	}
 	// request to go back to menu
 	if(MenuRequested())
 		ScreenshotRequested = 1; // go to the menu

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -155,6 +155,7 @@ preparePrefsData ()
 	createXMLSetting("hideoverscan", "Video Cropping", toStr(GCSettings.hideoverscan));
 	createXMLSetting("xshift", "Horizontal Video Shift", toStr(GCSettings.xshift));
 	createXMLSetting("yshift", "Vertical Video Shift", toStr(GCSettings.yshift));
+	createXMLSetting("TurboModeEnabled", "Turbo Mode Enabled", toStr(GCSettings.TurboModeEnabled));
 
 	createXMLSection("Menu", "Menu Settings");
 
@@ -329,6 +330,7 @@ decodePrefsData ()
 			loadXMLSetting(&GCSettings.hideoverscan, "hideoverscan");
 			loadXMLSetting(&GCSettings.xshift, "xshift");
 			loadXMLSetting(&GCSettings.yshift, "yshift");
+			loadXMLSetting(&GCSettings.TurboModeEnabled, "TurboModeEnabled");
 
 			// Menu Settings
 
@@ -456,6 +458,7 @@ DefaultSettings ()
 	sprintf (GCSettings.ArtworkFolder, "%s/artwork", APPFOLDER); // Path to artwork files
 	GCSettings.AutoLoad = 1; // Auto Load RAM
 	GCSettings.AutoSave = 1; // Auto Save RAM
+	GCSettings.TurboModeEnabled = 1; // Enabled by default
 }
 
 /****************************************************************************


### PR DESCRIPTION
So I got inspired by this [pull request](https://github.com/dborth/snes9xgx/pull/1005) made to Snes9x GX made by @InfiniteBlueGX for add the posibility to enable or disable the Turbo Mode feature.

These changes added an option to the Video Settings menu to toggle on/off the "Turbo Mode" feature from the right analog stick. When disabled, holding the stick to the right does not activate Turbo Mode. The setting is enabled by default.

The setting is saved to XML and the user's choice persists upon application re-entry.

I had to modify a different file for make this work but it works like a charm.

This will be utile because for newer releases of FCEUGX we won't need a separated build with disabled Turbo Mode, will need only to manually enable/disable it on Video Settings.