### PR TITLE
Add a toggle to hide/show the "Save RAM" button

### DIFF
--- a/source/fceugx.h
+++ b/source/fceugx.h
@@ -121,6 +121,7 @@ struct SGCSettings
 	int		Rumble;
 	int 	language;
 	int		PreviewImage;
+	int		HideRAMSaving;
 	int		TurboModeEnabled; // 0 - disabled, 1 - enabled
 };
 

--- a/source/gui/gui_savebrowser.cpp
+++ b/source/gui/gui_savebrowser.cpp
@@ -269,7 +269,10 @@ void GuiSaveBrowser::Update(GuiTrigger * t)
 		}
 		else
 		{
-			selectedItem -= 1;
+			if(saveBtn[selectedItem-1]->IsVisible())
+			{
+				selectedItem -= 1;
+			}
 		}
 	}
 	else if(t->Down() || arrowDownBtn->GetState() == STATE_CLICKED)
@@ -307,7 +310,10 @@ void GuiSaveBrowser::Update(GuiTrigger * t)
 		}
 		else
 		{
-			selectedItem -= 2;
+			if(saveBtn[selectedItem-2]->IsVisible())
+			{
+				selectedItem -= 2;
+			}
 		}
 	}
 
@@ -324,20 +330,25 @@ void GuiSaveBrowser::Update(GuiTrigger * t)
 		if(listOffset+i < 0 && action == 1)
 		{
 			saveDate[0]->SetText(NULL);
-			saveDate[1]->SetText(NULL);
 			saveTime[0]->SetText("New");
-			saveTime[1]->SetText("New");
-			saveType[0]->SetText("RAM");
-			saveType[1]->SetText("State");
+			saveType[0]->SetText("State");
 			savePreviewImg[0]->SetImage(gameSaveBlank);
-			savePreviewImg[1]->SetImage(gameSaveBlank);
 			saveBtn[0]->SetVisible(true);
-			saveBtn[1]->SetVisible(true);
 
 			if(saveBtn[0]->GetState() == STATE_DISABLED)
 				saveBtn[0]->SetState(STATE_DEFAULT);
-			if(saveBtn[1]->GetState() == STATE_DISABLED)
-				saveBtn[1]->SetState(STATE_DEFAULT);
+
+			if (GCSettings.HideRAMSaving == 0)
+			{
+				saveDate[1]->SetText(NULL);
+				saveTime[1]->SetText("New");
+				saveType[1]->SetText("RAM");
+				savePreviewImg[1]->SetImage(gameSaveBlank);
+				saveBtn[1]->SetVisible(true);
+
+				if(saveBtn[1]->GetState() == STATE_DISABLED)
+					saveBtn[1]->SetState(STATE_DEFAULT);
+			}
 		}
 		else if(listOffset+i < saves->length)
 		{

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -1998,20 +1998,7 @@ static int MenuGameSaves(int action)
 			}
 			else // save
 			{
-				if(ret == -2) // new RAM
-				{
-					for(i=1; i < 100; i++)
-						if(saves.files[FILE_RAM][i] == 0)
-							break;
-
-					if(i < 100)
-					{
-						MakeFilePath(filepath, FILE_RAM, romFilename, i);
-						SaveRAM(filepath, NOTSILENT);
-						menu = MENU_GAME_SAVE;
-					}
-				}
-				else if(ret == -1) // new State
+				if(ret == -2) // new State
 				{
 					for(i=1; i < 100; i++)
 						if(saves.files[FILE_STATE][i] == 0)
@@ -2021,6 +2008,19 @@ static int MenuGameSaves(int action)
 					{
 						MakeFilePath(filepath, FILE_STATE, romFilename, i);
 						SaveState(filepath, NOTSILENT);
+						menu = MENU_GAME_SAVE;
+					}
+				}
+				else if(ret == -1 && GCSettings.HideRAMSaving == 0) // new RAM
+				{
+					for(i=1; i < 100; i++)
+						if(saves.files[FILE_RAM][i] == 0)
+							break;
+
+					if(i < 100)
+					{
+						MakeFilePath(filepath, FILE_RAM, romFilename, i);
+						SaveRAM(filepath, NOTSILENT);
 						menu = MENU_GAME_SAVE;
 					}
 				}
@@ -3943,6 +3943,7 @@ static int MenuSettingsMenu()
 	sprintf(options.name[i++], "Rumble");
 	sprintf(options.name[i++], "Language");
 	sprintf(options.name[i++], "Preview Image");
+	sprintf(options.name[i++], "Hide RAM Saving");
 	options.length = i;
 
 	for(i=0; i < options.length; i++)
@@ -4028,6 +4029,9 @@ static int MenuSettingsMenu()
 				if(GCSettings.PreviewImage > 2)
 					GCSettings.PreviewImage = 0;
 				break;
+			case 7:
+				GCSettings.HideRAMSaving ^= 1;
+				break;
 		}
 
 		if(ret >= 0 || firstRun)
@@ -4076,6 +4080,11 @@ static int MenuSettingsMenu()
 				sprintf (options.value[4], "Enabled");
 			else
 				sprintf (options.value[4], "Disabled");
+
+			if (GCSettings.HideRAMSaving == 1)
+				sprintf (options.value[7], "On");
+			else
+				sprintf (options.value[7], "Off");
 
 			switch(GCSettings.language)
 			{

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -169,6 +169,7 @@ preparePrefsData ()
 	createXMLSetting("Rumble", "Rumble", toStr(GCSettings.Rumble));
 	createXMLSetting("language", "Language", toStr(GCSettings.language));
 	createXMLSetting("PreviewImage", "Preview Image", toStr(GCSettings.PreviewImage));
+	createXMLSetting("HideRAMSaving", "Hide RAM Saving", toStr(GCSettings.HideRAMSaving));
 
 	createXMLSection("Controller", "Controller Settings");
 
@@ -342,6 +343,7 @@ decodePrefsData ()
 			loadXMLSetting(&GCSettings.Rumble, "Rumble");
 			loadXMLSetting(&GCSettings.language, "language");
 			loadXMLSetting(&GCSettings.PreviewImage, "PreviewImage");
+			loadXMLSetting(&GCSettings.HideRAMSaving, "HideRAMSaving");
 			
 			// Controller Settings
 
@@ -439,6 +441,7 @@ DefaultSettings ()
 	GCSettings.SFXVolume = 40;
 	GCSettings.Rumble = 1; // Enabled
 	GCSettings.PreviewImage = 0;
+	GCSettings.HideRAMSaving = 0;
 	
 #ifdef HW_RVL
 	GCSettings.language = CONF_GetLanguage();


### PR DESCRIPTION
Similar to the feature in Snes9xGX, this toggle in the "Menu" settings allows toggling on/off the Save RAM button, because it often gets in the way of making save states for users who don't need RAM saving (most users, I'd imagine).