### PR TITLE
Update GitHub's "Upload Artifact Builds" plugin to v3.1.0 on workflow

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -36,7 +36,7 @@ jobs:
         cp executables/fceugx-wii.dol dist/FCEUltraGX/apps/fceugx/boot.dol
 
     - name: Upload Wii artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       if: ${{ matrix.image == 'Wii' }}
       with: 
         name: FCEUltraGX
@@ -55,7 +55,7 @@ jobs:
         cp executables/fceugx-gc.dol dist/FCEUltraGX-GameCube/
         
     - name: Upload GameCube artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       if: ${{ matrix.image == 'GameCube' }}
       with: 
         name: FCEUltraGX-GameCube


### PR DESCRIPTION
Since GitHub will make obsolete (deprecated) the v2 version of the Upload Artifact Builds, which the workflow used, i decided to update the workflow of GitHub to the latest v3.1.0.