### PR TITLE
Fix a crash upon relaunching after removing a SD/USB device

### DIFF
--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -634,7 +634,9 @@ bool LoadPrefs()
 		FixInvalidSettings();
 
 	// attempt to create directories if they don't exist
-	if(GCSettings.LoadMethod == DEVICE_SD || GCSettings.LoadMethod == DEVICE_USB) {
+	if((GCSettings.LoadMethod == DEVICE_SD && ChangeInterface(DEVICE_SD, SILENT))
+		|| (GCSettings.LoadMethod == DEVICE_USB && ChangeInterface(DEVICE_USB, SILENT)))  
+	{
 		char dirPath[MAXPATHLEN];
 		sprintf(dirPath, "%s%s", pathPrefix[GCSettings.LoadMethod], GCSettings.ScreenshotsFolder);
 		CreateDirectory(dirPath);


### PR DESCRIPTION
This fixes the same issue as https://github.com/dborth/snes9xgx/pull/1034 in FCEUGX.