### PR TITLE
Add Pre-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build FCE Ultra GX
+    name: Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -61,3 +61,41 @@ jobs:
         name: FCEUltraGX-GameCube
         path: |
          dist/FCEUltraGX-GameCube/
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.ref == 'refs/heads/master'
+    
+    steps:
+    - uses: actions/checkout@v3
+      name: Download Artifacts
+    
+    - uses: actions/download-artifact@v3
+      with:
+        path: dist
+    
+    - name: Re-zip artifacts
+      run: |
+        cd dist
+        rm -r FCEUltraGX/fceugx/cheats/*
+        rm -r FCEUltraGX/fceugx/roms/*
+        rm -r FCEUltraGX/fceugx/saves/*
+        zip -r FCEUltraGX.zip FCEUltraGX
+        zip -r FCEUltraGX-GameCube.zip FCEUltraGX-GameCube
+    
+    - name: Update Git Tag
+      run: |
+        git tag -f Pre-release
+        git push -f origin Pre-release
+    
+    - name: Create Release
+      uses: ncipollo/release-action@v1
+      with:
+        prerelease: true
+        allowUpdates: true
+        removeArtifacts: true
+        replacesArtifacts: false
+        tag: Pre-release
+        artifacts: "dist/*.zip"


### PR DESCRIPTION
Hi @dborth because the Nightly builds will expire over time I've added a Pre-release under the Releases section:
![image](https://user-images.githubusercontent.com/24655170/205279006-1e308e44-d9e2-4cbc-b04e-b52b6c150beb.png)

The Pre-release looks like the following, everytime an update to the master branch is triggered it will overwrite the previous Pre-Release. I also removed the cheatsdir, romsdir and savesdir dummy files from the zip file:
![image](https://user-images.githubusercontent.com/24655170/205276758-08d42163-5d23-4b52-9a79-05e6fa18aa80.png)

