### PR TITLE
"Official Site" too close to "Credits"

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -837,7 +837,7 @@ static void WindowCredits(void * ptr)
 	GuiText * txt[numEntries];
 
 	txt[i] = new GuiText("Credits", 30, (GXColor){0, 0, 0, 255});
-	txt[i]->SetAlignment(ALIGN_CENTRE, ALIGN_TOP); txt[i]->SetPosition(0,y); i++; y+=24;
+	txt[i]->SetAlignment(ALIGN_CENTRE, ALIGN_TOP); txt[i]->SetPosition(0,y); i++; y+=32;
 
 	txt[i] = new GuiText("Official Site: https://github.com/dborth/fceugx", 20, (GXColor){0, 0, 0, 255});
 	txt[i]->SetAlignment(ALIGN_CENTRE, ALIGN_TOP); txt[i]->SetPosition(0,y); i++; y+=32;


### PR DESCRIPTION
When I choose Chinese as the UI Language, "Official Site" too close to "Credits":

![OHBCHB_2023-11-07_18-44-48](https://github.com/dborth/fceugx/assets/150144639/5be49225-f906-46b6-8cbb-f618e679c2d1)

`txt[i]->SetAlignment(ALIGN_CENTRE, ALIGN_TOP); txt[i]->SetPosition(0,y); i++; y+=32;`

The same as snes9xgx/source/menu.cpp line 838.
