### PR TITLE
Add GCLoader support

### DIFF
--- a/source/fceugx.h
+++ b/source/fceugx.h
@@ -25,8 +25,8 @@
 #define NOTSILENT 0
 #define SILENT 1
 
-const char pathPrefix[9][8] =
-{ "", "sd:/", "usb:/", "dvd:/", "smb:/", "carda:/", "cardb:/", "port2:/" };
+const char pathPrefix[10][11] =
+{ "", "sd:/", "usb:/", "dvd:/", "smb:/", "carda:/", "cardb:/", "port2:/", "gcloader:/" };
 
 enum 
 {
@@ -37,7 +37,8 @@ enum
 	DEVICE_SMB,
 	DEVICE_SD_SLOTA,
 	DEVICE_SD_SLOTB,
-	DEVICE_SD_PORT2
+	DEVICE_SD_PORT2,
+	DEVICE_SD_GCLOADER,
 };
 
 enum 

--- a/source/filebrowser.cpp
+++ b/source/filebrowser.cpp
@@ -69,6 +69,8 @@ int autoLoadMethod()
 		device = DEVICE_SD_SLOTB;
 	else if(ChangeInterface(DEVICE_SD_PORT2, SILENT))
 		device = DEVICE_SD_PORT2;
+	else if(ChangeInterface(DEVICE_SD_GCLOADER, SILENT))
+		device = DEVICE_SD_GCLOADER;
 	else if(ChangeInterface(DEVICE_DVD, SILENT))
 		device = DEVICE_DVD;
 	else if(ChangeInterface(DEVICE_SMB, SILENT))
@@ -102,6 +104,8 @@ int autoSaveMethod(bool silent)
 		device = DEVICE_SD_SLOTB;
 	else if(ChangeInterface(DEVICE_SD_PORT2, SILENT))
 		device = DEVICE_SD_PORT2;
+	else if(ChangeInterface(DEVICE_SD_GCLOADER, SILENT))
+		device = DEVICE_SD_GCLOADER;
 	else if(ChangeInterface(DEVICE_SMB, SILENT))
 		device = DEVICE_SMB;
 	else if(!silent)
@@ -172,7 +176,8 @@ bool IsDeviceRoot(char * path)
 		strcmp(path, "smb:/")   == 0 ||
 		strcmp(path, "carda:/") == 0 ||
 		strcmp(path, "cardb:/") == 0 ||
-        strcmp(path, "port2:/") == 0 )
+        strcmp(path, "port2:/") == 0 ||
+		strcmp(path, "gcloader:/") == 0 )
 	{
 		return true;
 	}

--- a/source/fileop.cpp
+++ b/source/fileop.cpp
@@ -45,8 +45,8 @@ unsigned char *savebuffer = NULL;
 u8 *ext_font_ttf = NULL;
 static mutex_t bufferLock = LWP_MUTEX_NULL;
 FILE * file; // file pointer - the only one we should ever use!
-bool unmountRequired[8] = { false, false, false, false, false, false, false, false };
-bool isMounted[8] = { false, false, false, false, false, false, false, false };
+bool unmountRequired[9] = { false, false, false, false, false, false, false, false, false };
+bool isMounted[9] = { false, false, false, false, false, false, false, false, false };
 
 #ifdef HW_RVL
 	static DISC_INTERFACE* sd = &__io_wiisd;
@@ -57,6 +57,7 @@ bool isMounted[8] = { false, false, false, false, false, false, false, false };
 	static DISC_INTERFACE* cardb = &__io_gcsdb;
 	static DISC_INTERFACE* port2 = &__io_gcsd2;
 	static DISC_INTERFACE* dvd = &__io_gcdvd;
+	static DISC_INTERFACE* gcloader = &__io_gcode;
 #endif
 
 // folder parsing thread
@@ -209,6 +210,7 @@ void UnmountAllFAT()
 	fatUnmount("port2:");
 	fatUnmount("carda:");
 	fatUnmount("cardb:");
+	fatUnmount("gcloader:");
 #endif
 }
 
@@ -257,6 +259,11 @@ static bool MountFAT(int device, int silent)
 			sprintf(name, "port2");
 			sprintf(name2, "port2:");
 			disc = port2;
+			break;
+		case DEVICE_SD_GCLOADER:
+			sprintf(name, "gcloader");
+			sprintf(name2, "gcloader:");
+			disc = gcloader;
 			break;
 #endif
 		default:
@@ -393,6 +400,11 @@ bool FindDevice(char * filepath, int * device)
 		*device = DEVICE_DVD;
 		return true;
 	}
+	else if(strncmp(filepath, "gcloader:", 9) == 0)
+	{
+		*device = DEVICE_SD_GCLOADER;
+		return true;
+	}
 	return false;
 }
 
@@ -429,6 +441,7 @@ bool ChangeInterface(int device, bool silent)
 		case DEVICE_SD_SLOTA:
 		case DEVICE_SD_SLOTB:
 		case DEVICE_SD_PORT2:
+		case DEVICE_SD_GCLOADER:
 #endif
 			mounted = MountFAT(device, silent);
 			break;

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -4177,9 +4177,9 @@ static int MenuSettingsFile()
 			#endif
 
 			// correct load/save methods out of bounds
-			if(GCSettings.LoadMethod > 7)
+			if(GCSettings.LoadMethod > 8)
 				GCSettings.LoadMethod = 0;
-			if(GCSettings.SaveMethod > 7)
+			if(GCSettings.SaveMethod > 8)
 				GCSettings.SaveMethod = 0;
 
 			if (GCSettings.LoadMethod == DEVICE_AUTO) sprintf (options.value[0],"Auto Detect");
@@ -4190,6 +4190,7 @@ static int MenuSettingsFile()
 			else if (GCSettings.LoadMethod == DEVICE_SD_SLOTA) sprintf (options.value[0],"SD Gecko Slot A");
 			else if (GCSettings.LoadMethod == DEVICE_SD_SLOTB) sprintf (options.value[0],"SD Gecko Slot B");
 			else if (GCSettings.LoadMethod == DEVICE_SD_PORT2) sprintf (options.value[0],"SD in SP2");
+			else if (GCSettings.LoadMethod == DEVICE_SD_GCLOADER) sprintf (options.value[0],"GC Loader");
 
 			if (GCSettings.SaveMethod == DEVICE_AUTO) sprintf (options.value[1],"Auto Detect");
 			else if (GCSettings.SaveMethod == DEVICE_SD) sprintf (options.value[1],"SD");
@@ -4198,6 +4199,7 @@ static int MenuSettingsFile()
 			else if (GCSettings.SaveMethod == DEVICE_SD_SLOTA) sprintf (options.value[1],"SD Gecko Slot A");
 			else if (GCSettings.SaveMethod == DEVICE_SD_SLOTB) sprintf (options.value[1],"SD Gecko Slot B");
 			else if (GCSettings.SaveMethod == DEVICE_SD_PORT2) sprintf (options.value[1],"SD in SP2");
+			else if (GCSettings.SaveMethod == DEVICE_SD_GCLOADER) sprintf (options.value[1],"GC Loader");
 
 			snprintf (options.value[2], 35, "%s", GCSettings.LoadFolder);
 			snprintf (options.value[3], 35, "%s", GCSettings.SaveFolder);

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -379,9 +379,9 @@ decodePrefsData ()
  ***************************************************************************/
 void FixInvalidSettings()
 {
-	if(GCSettings.LoadMethod > 7)
+	if(GCSettings.LoadMethod > 8)
 		GCSettings.LoadMethod = DEVICE_AUTO;
-	if(GCSettings.SaveMethod > 7)
+	if(GCSettings.SaveMethod > 8)
 		GCSettings.SaveMethod = DEVICE_AUTO;
 	if(!(GCSettings.zoomHor > 0.5 && GCSettings.zoomHor < 1.5))
 		GCSettings.zoomHor = 1.0;
@@ -624,6 +624,10 @@ bool LoadPrefs()
 	}
 	else if(ChangeInterface(DEVICE_SD_PORT2, SILENT)) {
 		sprintf(filepath[0], "port2:/%s", APPFOLDER);
+		prefFound = LoadPrefsFromMethod(filepath[0]);
+	}
+	else if(ChangeInterface(DEVICE_SD_GCLOADER, SILENT)) {
+		sprintf(filepath[0], "gcloader:/%s", APPFOLDER);
 		prefFound = LoadPrefsFromMethod(filepath[0]);
 	}
 #endif


### PR DESCRIPTION
Hello! I got a [GC Loader](https://gc-forever.com/wiki/index.php?title=GCLoader) as my intro to the GC homebrew scene and I was a bit disappointed to find out that a lot of homebrew doesn't support it.

I added the GC Loader as an option for saving/loading and ROMs here by adding it as an option everywhere I could find that the other SD card options are referenced. I booted it up and played a bit, I was able to browse and load ROMs and load/save states.

Let me know if there's more I can do!