### PR TITLE
Add GC Loader to `filebrowser.cpp` and use `pkg-config` for Freetype

### DIFF
--- a/Makefile.gc
+++ b/Makefile.gc
@@ -10,6 +10,8 @@ endif
 include $(DEVKITPPC)/gamecube_rules
 export	LIBOGC_INC	:=	$(DEVKITPRO)/libogc2/include
 export	LIBOGC_LIB	:=	$(DEVKITPRO)/libogc2/lib/cube
+export	FREETYPE_CFLAGS 	:=	`$(DEVKITPRO)/portlibs/ppc/bin/powerpc-eabi-pkg-config --cflags freetype2`
+export	FREETYPE_LIBS	:=	`$(DEVKITPRO)/portlibs/ppc/bin/powerpc-eabi-pkg-config --libs freetype2`
 
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
@@ -30,7 +32,7 @@ INCLUDES	:=	source
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-SHAREDFLAGS	=	-g -O3 -Wall $(MACHDEP) $(INCLUDE) `freetype-config --cflags` \
+SHAREDFLAGS	=	-g -O3 -Wall $(MACHDEP) $(INCLUDE) $(FREETYPE_CFLAGS) \
 				-DFRAMESKIP -DPSS_STYLE=1 -DPATH_MAX=1024 -DHAVE_ASPRINTF \
 				-D_SZ_ONE_DIRECTORY -D_LZMA_IN_CB -D_LZMA_OUT_READ -DNOUNCRYPT -DNO_SOUND -DUSE_VM \
 				-fomit-frame-pointer \
@@ -46,7 +48,7 @@ LDFLAGS		+=	-L../buildtools
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:= -lpng -lmxml -ltinysmb -lbba -lfat -liso9660 -lasnd -lz -logc `freetype-config --libs`
+LIBS	:= -lpng -lmxml -ltinysmb -lbba -lfat -liso9660 -lasnd -lz -logc $(FREETYPE_LIBS)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/Makefile.wii
+++ b/Makefile.wii
@@ -10,6 +10,8 @@ endif
 include $(DEVKITPPC)/wii_rules
 export	LIBOGC_INC	:=	$(DEVKITPRO)/libogc2/include
 export	LIBOGC_LIB	:=	$(DEVKITPRO)/libogc2/lib/wii
+export	FREETYPE_CFLAGS 	:=	`$(DEVKITPRO)/portlibs/ppc/bin/powerpc-eabi-pkg-config --cflags freetype2`
+export	FREETYPE_LIBS	:=	`$(DEVKITPRO)/portlibs/ppc/bin/powerpc-eabi-pkg-config --libs freetype2`
 
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
@@ -30,7 +32,7 @@ INCLUDES	:=	source
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-SHAREDFLAGS	=	-g -O3 -Wall $(MACHDEP) $(INCLUDE) `freetype-config --cflags` \
+SHAREDFLAGS	=	-g -O3 -Wall $(MACHDEP) $(INCLUDE) $(FREETYPE_CFLAGS) \
 				-DFRAMESKIP -DPSS_STYLE=1 -DPATH_MAX=1024 -DHAVE_ASPRINTF \
 				-D_SZ_ONE_DIRECTORY -D_LZMA_IN_CB -D_LZMA_OUT_READ -DNOUNCRYPT \
 				-fomit-frame-pointer \
@@ -46,7 +48,7 @@ LDFLAGS		+=	-L../buildtools
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:=	-ldi -liso9660 -lpng -lmxml `freetype-config --libs` \
+LIBS	:=	-ldi -liso9660 -lpng -lmxml $(FREETYPE_LIBS) \
 			-lfat -lwiiuse -lz -lbte -lasnd -logc -lvorbisidec -logg -ltinysmb
 
 #---------------------------------------------------------------------------------

--- a/source/filebrowser.cpp
+++ b/source/filebrowser.cpp
@@ -644,6 +644,14 @@ int BrowserChangeFolder()
 		browserList[i].isdir = 1;
 		browserList[i].icon = ICON_SD;
 		i++;
+
+		AddBrowserEntry();
+		sprintf(browserList[i].filename, "gcloader:/");
+		sprintf(browserList[i].displayname, "GC Loader");
+		browserList[i].length = 0;
+		browserList[i].isdir = 1;
+		browserList[i].icon = ICON_SD;
+		i++;
 #endif
 		AddBrowserEntry();
 		sprintf(browserList[i].filename, "smb:/");


### PR DESCRIPTION
Hello! I am back with another trio of PRs.

My goal was to add the GC Loader to the filebrowser, which I had overlooked in my last PR. But in doing so I was also building against the newest devkitPPC and libogc2 and had to fix some build errors there.

As of https://github.com/devkitPro/pacman-packages/commit/846bd804e003d56b153bd80a01ce2ecd088d9f30, `freetype-config` doesn't seem like it's being shipped with ppc-freetype anymore, so I switched to using pkg-config just for that library.

I tested this on my Gamecube, but unfortunately I don't have a Wii to test against so I can't say if it works there - but it does build.