### PR TITLE
Fix legacy return to loader

### DIFF
--- a/source/mem2.cpp
+++ b/source/mem2.cpp
@@ -29,9 +29,9 @@ void* mem2_malloc(u32 size)
 	return __lwp_heap_allocate(&mem2_heap, size);
 }
 
-bool mem2_free(void *ptr)
+void mem2_free(void *ptr)
 {
-	return __lwp_heap_free(&mem2_heap, ptr);
+	__lwp_heap_free(&mem2_heap, ptr);
 }
 
 #endif

--- a/source/mem2.h
+++ b/source/mem2.h
@@ -16,7 +16,7 @@
 
 u32 InitMem2Manager ();
 void* mem2_malloc(u32 size);
-bool mem2_free(void *ptr);
+void mem2_free(void *ptr);
 
 #endif
 

--- a/source/system.cpp
+++ b/source/system.cpp
@@ -11,6 +11,7 @@
 
 #include <gccore.h>
 #include <sys/iosupport.h>
+#include <ogc/lwp_threads.h>
 
 #ifdef HW_RVL
 #include <di/di.h>
@@ -279,9 +280,14 @@ void SystemExit(int exitAction, bool autoloadedGame)
 	else // Exit to Loader
 	{
 		if (psoid[0] == PSOSDLOADID)
-			PSOReload();
+		{
+			SYS_ResetSystem(SYS_SHUTDOWN, 0, FALSE);
+			__lwp_thread_stopmultitasking(PSOReload);
+		}
 		else
+		{
 			exit(0);
+		}
 	}
 #endif
 }


### PR DESCRIPTION
This fixes the black screen issue that has been reported.
However, it would appear there's a deeper issue hiding somewhere in libogc2.

Note: Calling `exit` is sufficient to return to Swiss.